### PR TITLE
Pass account_id directly to resources

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,8 +23,8 @@ resource "cloudflare_worker_script" "this" {
 }
 
 data "cloudflare_zones" "this" {
-  account_id = var.account_id
   filter {
+    account_id = var.account_id
     name = var.cloudflare_zone
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,5 @@
 resource "cloudflare_worker_script" "this" {
+  account_id = var.account_id
   name = format("maintenance-%s", replace(var.cloudflare_zone, ".", "-"))
   content = templatefile("${path.module}/maintenance.js", {
     company_name   = var.company_name
@@ -22,6 +23,7 @@ resource "cloudflare_worker_script" "this" {
 }
 
 data "cloudflare_zones" "this" {
+  account_id = var.account_id
   filter {
     name = var.cloudflare_zone
   }

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,9 @@
+variable "account_id" {
+  type = string
+  description = "Cloudflare account id"
+  default = null
+}
+
 variable "cloudflare_zone" {
   type = string
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "> 2.0.0"
+      version = ">= 3.31.0"
     }
   }
   required_version = ">= 0.13"


### PR DESCRIPTION
As of version 4.0 of the Cloudflare provider, `account_id` is no longer a valid parameter for the provider and must be provided to resources that require it. In order to transition to this the provider added optional `account_id` parameters and started emitting warnings about this new behaviour in 3.31.

This change adds an optional `account_id` variable, and should support provider versions 3.31 and higher, including 4.