### PR TITLE
feat: Add variable to customize main image

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Example can be found in examples/root-example.
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13 |
+| terraform | >= 1.0.0 |
 | cloudflare | >= 5.1.0 |
 
 ## Providers
@@ -82,7 +82,7 @@ Example can be found in examples/root-example.
 |------|------|
 | [cloudflare_workers_route.this](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/workers_route) | resource |
 | [cloudflare_workers_script.this](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/workers_script) | resource |
-| [cloudflare_zones.this](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/data-sources/zones) | data source |
+| [cloudflare_zone.this](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/data-sources/zone) | data source |
 
 ## Inputs
 
@@ -95,6 +95,7 @@ Example can be found in examples/root-example.
 | enabled | Flag to create/delete the worker route. | `bool` | `true` | no |
 | favicon\_url | The favicon to be displayed. Defaults to a maintenance icon from the web. | `string` | `"https://cdn1.iconfinder.com/data/icons/ios-11-glyphs/30/maintenance-512.png"` | no |
 | font | [Google font](https://fonts.google.com/) that should be used. | `string` | `"Poppins"` | no |
+| image\_url | The main image to be displayed. | `string` | `"https://i.imgur.com/0uJkCM8.png"` | no |
 | logo\_url | The logo to be displayed. | `string` | n/a | yes |
 | patterns | The DNS pattern list to deploy the maintenance page to. | `list(string)` | n/a | yes |
 | statuspage\_url | The status page address to get updated information. | `string` | `"null"` | no |

--- a/main.tf
+++ b/main.tf
@@ -5,6 +5,7 @@ resource "cloudflare_workers_script" "this" {
     company_name   = var.company_name
     logo_url       = var.logo_url
     favicon_url    = var.favicon_url
+    image_url      = var.image_url
     font           = var.font
     email          = var.email
     statuspage_url = var.statuspage_url

--- a/maintenance.js
+++ b/maintenance.js
@@ -127,7 +127,9 @@ const maintenancePage = `
             %{ endif }
             <p>&mdash; ${company_name}</p>
         </div>
-        <img class="image-main" src="https://i.imgur.com/0uJkCM8.png" alt="Maintenance image">
+        %{ if image_url != "" }
+        <img class="image-main" src="${image_url}" alt="Maintenance image">
+        %{ endif }
         <hr />
         <a href="mailto:${email}?subject=Maintenance">You can reach us at: ${email}</a>
     </div>

--- a/variables.tf
+++ b/variables.tf
@@ -45,6 +45,12 @@ variable "favicon_url" {
   description = "The favicon to be displayed. Defaults to a maintenance icon from the web."
 }
 
+variable "image_url" {
+  type        = string
+  default     = "https://i.imgur.com/0uJkCM8.png"
+  description = "The main image to be displayed."
+}
+
 variable "enabled" {
   type        = bool
   default     = true


### PR DESCRIPTION
Add a new variable `image_url` to allow users to customize the main image displayed on the maintenance page.

This variable's default value is kept for backward compatibility, but users can now specify their own image URL, or leave it empty to hide the image.