### PR TITLE
feat: Add variable to customize page info section

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Example can be found in examples/root-example.
 | favicon\_url | The favicon to be displayed. Defaults to a maintenance icon from the web. | `string` | `"https://cdn1.iconfinder.com/data/icons/ios-11-glyphs/30/maintenance-512.png"` | no |
 | font | [Google font](https://fonts.google.com/) that should be used. | `string` | `"Poppins"` | no |
 | image\_url | The main image to be displayed. | `string` | `"https://i.imgur.com/0uJkCM8.png"` | no |
+| info\_html | The HTML to be displayed in the info section. | `string` | `"<h1>Our site is currently down for maintenance</h1>\n<p>We apologize for any inconvenience caused and we will be online as soon as possible. Please check again in a little while. Thank you!</p>\n"` | no |
 | logo\_url | The logo to be displayed. | `string` | n/a | yes |
 | patterns | The DNS pattern list to deploy the maintenance page to. | `list(string)` | n/a | yes |
 | statuspage\_url | The status page address to get updated information. | `string` | `"null"` | no |

--- a/main.tf
+++ b/main.tf
@@ -8,6 +8,7 @@ resource "cloudflare_workers_script" "this" {
     image_url      = var.image_url
     font           = var.font
     email          = var.email
+    info_html      = var.info_html
     statuspage_url = var.statuspage_url
     google_font    = replace(var.font, " ", "+")
   })

--- a/maintenance.js
+++ b/maintenance.js
@@ -120,8 +120,9 @@ const maintenancePage = `
     <div class="content">
         <img class="logo" src="${logo_url}" alt="${company_name}">
         <div class="info">
-            <h1>Our site is currently down for maintenance</h1>
-            <p>We apologize for any inconvenience caused and we will be online as soon as possible. Please check again in a little while. Thank you!</p>
+            {% if info_html != "" %}
+            ${info_html}
+            {% endif %}
             %{ if statuspage_url != "null" }
             <p>You can follow the updated information on our <a href="${statuspage_url}">status page</a>.</p>
             %{ endif }

--- a/variables.tf
+++ b/variables.tf
@@ -51,6 +51,15 @@ variable "image_url" {
   description = "The main image to be displayed."
 }
 
+variable "info_html" {
+  type        = string
+  default     = <<-EOT
+    <h1>Our site is currently down for maintenance</h1>
+    <p>We apologize for any inconvenience caused and we will be online as soon as possible. Please check again in a little while. Thank you!</p>
+  EOT
+  description = "The HTML to be displayed in the info section."
+}
+
 variable "enabled" {
   type        = bool
   default     = true


### PR DESCRIPTION
Add a new variable `info_html` to allow users to customize the HTML content displayed in the info section of the maintenance page. This provides flexibility for users to tailor the message according to their needs.

This variable's default value is kept for backward compatibility.